### PR TITLE
[ROO-25] fix: ensure that nextSelection is a valid selection before setting it

### DIFF
--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -126,11 +126,14 @@ export function syncYjsChangesToLexical(
             );
             const [start, end] =
               prevOffsetView.getOffsetsFromSelection(prevSelection);
-            const nextSelection = nextOffsetView.createSelectionFromOffsets(
-              start,
-              end,
-              prevOffsetView,
-            );
+            const nextSelection =
+              start >= 0 && end >= 0
+                ? nextOffsetView.createSelectionFromOffsets(
+                    start,
+                    end,
+                    prevOffsetView,
+                  )
+                : null;
 
             if (nextSelection !== null) {
               $setSelection(nextSelection);


### PR DESCRIPTION
### Ticket

[ROO-25 - Unable to enter new paragraph after undo of newline](https://linear.app/jasper-ai/issue/ROO-25/unable-to-enter-new-paragraph-after-undo-of-newline)

Issue that I posted: https://github.com/facebook/lexical/issues/4832

### Problem Statement

Unable to enter new paragraph after undo of newline

Steps to reproduce:
1. Enter a newline
2. Undo with cmd+z
3. Try to enter another newline


### Scope of work

`start` & `end` can be `-1` which results in the selection being in an invalid state


### Test cases

How it behaves with this fix now:

https://github.com/gojasper/lexical/assets/19589943/afadffa3-633e-4572-a925-f533ef05cb45



