### PR TITLE
[ROO-2236] fix: explicitly import instead of `window.` to support code node in n…

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -34,6 +34,7 @@ import {
   $isTextNode,
   ElementNode,
 } from 'lexical';
+import {languages} from 'prismjs';
 
 import {
   $createCodeHighlightNode,
@@ -53,7 +54,7 @@ const isLanguageSupportedByPrism = (
 ): boolean => {
   try {
     // eslint-disable-next-line no-prototype-builtins
-    return language ? window.Prism.languages.hasOwnProperty(language) : false;
+    return language ? languages.hasOwnProperty(language) : false;
   } catch {
     return false;
   }


### PR DESCRIPTION
…odejs

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Removing reference of `window` in order for `@lexical/code` to be used in node.js (headless editor)

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*