### PR TITLE
table patch fix

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -179,7 +179,7 @@ export class TableCellNode extends ElementNode {
       if (this.__rowSpan > 1) {
         element.rowSpan = this.__rowSpan;
       }
-      element.style.width = `${this.getWidth() || COLUMN_WIDTH}px`;
+      element.style.width = `${editor.getElementByKey(this.getKey())?.clientWidth || COLUMN_WIDTH}px`;
 
       element.style.verticalAlign = this.getVerticalAlign() || 'top';
       element.style.textAlign = 'start';


### PR DESCRIPTION
https://github.com/gojasper/beta-app/pull/8425

> Ticket(s)
> [ROO-4804](https://linear.app/jasper-ai/issue/ROO-4804/narrow-tables-in-pdf-downloads)
> Problem Statement
> Tables in the Document Editor were appearing too narrow when exported as PDF files. This occurred because Lexical table cell nodes didn't have explicit width values set, causing them to render with minimal width during PDF generation via HTML-to-PDF conversion. The narrow tables made content difficult to read and created a poor user experience when downloading documents.
> 
> Scope of Work
> Use a patch file to override the exportDOM behavior for tables, to use the real clientWidth instead of the default 75px from Lexical's constants when the width is missing from the Table Cell state